### PR TITLE
feat: 프로세스 관리 및 시스템 콜 구현 (fork, exec, wait, exit, 파일 관련 syscall)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,22 @@
         "*.inc": "c",
         "lib.h": "c",
         "inode.h": "c",
-        "interrupt.h": "c"
+        "interrupt.h": "c",
+        "file.h": "c",
+        "off_t.h": "c",
+        "loader.h": "c",
+        "filesys.h": "c",
+        "syscall.h": "c",
+        "synch.h": "c",
+        "mmu.h": "c",
+        "types.h": "c",
+        "gdt.h": "c",
+        "process.h": "c",
+        "flags.h": "c",
+        "vaddr.h": "c",
+        "util.h": "c",
+        "stddef.h": "c",
+        "main.h": "c",
+        "init.h": "c"
     },
 }

--- a/pintos/include/devices/disk.h
+++ b/pintos/include/devices/disk.h
@@ -23,5 +23,5 @@ disk_sector_t disk_size(struct disk *);
 void disk_read(struct disk *, disk_sector_t, void *);
 void disk_write(struct disk *, disk_sector_t, const void *);
 
-void register_disk_inspect_intr();
+void register_disk_inspect_intr(void);
 #endif /* devices/disk.h */

--- a/pintos/include/lib/user/syscall.h
+++ b/pintos/include/lib/user/syscall.h
@@ -7,7 +7,7 @@
 
 /* Process identifier. */
 typedef int pid_t;
-#define PID_ERROR ((pid_t) -1)
+#define PID_ERROR ((pid_t) - 1)
 
 /* Map region identifier. */
 typedef int off_t;
@@ -25,7 +25,7 @@ void halt(void) NO_RETURN;
 void exit(int status) NO_RETURN;
 pid_t fork(const char *thread_name);
 int exec(const char *file);
-int wait(pid_t);
+int wait(pid_t pid);
 bool create(const char *file, unsigned initial_size);
 bool remove(const char *file);
 int open(const char *file);

--- a/pintos/include/userprog/process.h
+++ b/pintos/include/userprog/process.h
@@ -9,5 +9,9 @@ int process_exec(void *f_name);
 int process_wait(tid_t);
 void process_exit(void);
 void process_activate(struct thread *next);
+struct thread *process_get_child(tid_t tid);
+struct uni_file *process_get_file(int fd);
+int process_add_file(struct file *file);
+void process_init_fdt(struct thread *t);
 
 #endif /* userprog/process.h */

--- a/pintos/include/userprog/syscall.h
+++ b/pintos/include/userprog/syscall.h
@@ -1,10 +1,8 @@
 #ifndef USERPROG_SYSCALL_H
 #define USERPROG_SYSCALL_H
-#define is_fd_readable(fd) (fd >= 2 && fd < 128)
-#define is_fd_writable(fd) (fd >= 1 && fd < 128)
 
+extern struct lock filesys_lock;
 void syscall_init(void);
-struct file *process_get_file(int fd);
-int process_add_file(struct file *file);
+void check_address(void *addr);
 
 #endif /* userprog/syscall.h */

--- a/pintos/include/userprog/syscall.h
+++ b/pintos/include/userprog/syscall.h
@@ -1,5 +1,7 @@
 #ifndef USERPROG_SYSCALL_H
 #define USERPROG_SYSCALL_H
+#define is_fd_readable(fd) (fd >= 2 && fd < 128)
+#define is_fd_writable(fd) (fd >= 1 && fd < 128)
 
 void syscall_init(void);
 struct file *process_get_file(int fd);

--- a/pintos/userprog/exception.c
+++ b/pintos/userprog/exception.c
@@ -3,6 +3,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#include "include/lib/user/syscall.h"
 #include "intrinsic.h"
 #include "threads/interrupt.h"
 #include "threads/thread.h"
@@ -154,5 +155,5 @@ static void page_fault(struct intr_frame *f)
     printf("Page fault at %p: %s error %s page in %s context.\n", fault_addr,
            not_present ? "not present" : "rights violation",
            write ? "writing" : "reading", user ? "user" : "kernel");
-    kill(f);
+    exit(-1);
 }

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -10,11 +10,14 @@
 #include "filesys/directory.h"
 #include "filesys/file.h"
 #include "filesys/filesys.h"
+#include "include/lib/string.h"
 #include "include/threads/mmu.h"
+#include "include/userprog/syscall.h"
 #include "intrinsic.h"
 #include "threads/flags.h"
 #include "threads/init.h"
 #include "threads/interrupt.h"
+#include "threads/malloc.h"
 #include "threads/mmu.h"
 #include "threads/palloc.h"
 #include "threads/synch.h"
@@ -78,19 +81,49 @@ static void initd(void *f_name)
     NOT_REACHED();
 }
 
-/* Clones the current process as `name`. Returns the new process's thread id, or
- * TID_ERROR if the thread cannot be created. */
+/* initialize fd_table. reserves stdin, stdout */
+void process_init_fdt(struct thread *t)
+{
+    t->fd_table[0] = malloc(sizeof(struct uni_file));
+    t->fd_table[1] = malloc(sizeof(struct uni_file));
+
+    t->fd_table[0]->type = FD_STDIN;
+    t->fd_table[0]->ptr = NULL;
+
+    t->fd_table[1]->type = FD_STDOUT;
+    t->fd_table[1]->ptr = NULL;
+}
+
+/* 현재 프로세스를 `name`으로 복제합니다.
+ * 복제된 프로세스의 스레드 ID를 반환하며,
+ * 스레드 생성에 실패할 경우 TID_ERROR를 반환합니다. */
 tid_t process_fork(const char *name, struct intr_frame *if_)
 {
     struct thread *curr = thread_current();
-    /* Clone current thread to new thread.*/
-    struct thread *fci_curr = malloc(sizeof(struct thread));
-    struct intr_frame *fci_if = malloc(sizeof(struct intr_frame));
-    memcpy(fci_if, if_, sizeof(if_));
-    curr->fci.curr = fci_curr;
-    curr->fci.if_ = fci_if;
 
-    return thread_create(name, PRI_DEFAULT, __do_fork, curr);
+    memcpy(&curr->parent_if, if_, sizeof(struct intr_frame));
+
+    /* PID: 복제된 자식 프로세스의 TID */
+    tid_t pid = thread_create(name, PRI_DEFAULT, __do_fork, curr);
+    if (pid == TID_ERROR)
+    {
+        return TID_ERROR;
+    }
+
+    struct thread *child = process_get_child(pid);
+
+    /* 부모 프로세스는 자식 프로세스의 fork 과정을 기다린다. */
+    sema_down(&child->fork_sema);
+
+    /* 자식 프로세스의 fork 과정이 어떤 결과로든 끝나면 이쪽이 실행된다.
+     * 이때 어떤 동작이 실패하여 자식의 종료 코드가 -1이면 부모가 실행하는
+     * process_fork 과정의 반환값은 TID_ERROR(-1)을 반환하도록 한다.  */
+    if (child->exit_status == TID_ERROR)
+    {
+        return TID_ERROR;
+    }
+
+    return pid;
 }
 
 #ifndef VM
@@ -112,17 +145,26 @@ static bool duplicate_pte(uint64_t *pte, void *va, void *aux)
 
     /* 2. Resolve VA from the parent's page map level 4. */
     parent_page = pml4_get_page(parent->pml4, va);
+    if (parent_page == NULL)
+    {
+        return false;
+    }
 
     /* 3. TODO: Allocate new PAL_USER page for the child and set result to
      *    TODO: NEWPAGE. */
-    newpage = palloc_get_page(PAL_USER);
+    newpage = palloc_get_page(PAL_USER | PAL_ZERO);
+    if (newpage == NULL)
+    {
+        return false;
+    }
 
     /* 4. TODO: Duplicate parent's page to the new page and
      *    TODO: check whether parent's page is writable or not (set WRITABLE
      *    TODO: according to the result). */
-    writable = is_writable(pte);
 
     memcpy(newpage, parent_page, PGSIZE);
+
+    writable = is_writable(pte);
 
     /* 5. Add new page to child's page table at address VA with WRITABLE
      *    permission. */
@@ -143,16 +185,16 @@ static bool duplicate_pte(uint64_t *pte, void *va, void *aux)
  *       this function. */
 static void __do_fork(void *aux)
 {
+    /* intr frame for jump to userland context */
     struct intr_frame if_;
-    struct fork_copy_info *fci = (struct fork_copy_info *) aux;
-    struct thread *parent = fci->curr;
-    struct intr_frame *parent_if = fci->if_;
-    struct thread *current = thread_current();  // 나 응애 자식
-    current->parent = parent;
+    struct thread *parent = (struct thread *) aux;
+    struct thread *current = thread_current();
+    struct intr_frame *parent_if = &parent->parent_if;
     bool succ = true;
 
     /* 1. Read the cpu context to local stack. */
     memcpy(&if_, parent_if, sizeof(struct intr_frame));
+    if_.R.rax = 0; /* 자식 프로세스의 return 값은 항상 0이다. */
 
     /* 2. Duplicate PT */
     current->pml4 = pml4_create();
@@ -166,24 +208,45 @@ static void __do_fork(void *aux)
     if (!pml4_for_each(parent->pml4, duplicate_pte, parent)) goto error;
 #endif
 
-    /* TODO: Your code goes here.
-     * TODO: Hint) To duplicate the file object, use `file_duplicate`
-     * TODO:       in include/filesys/file.h. Note that parent should not return
-     * TODO:       from the fork() until this function successfully duplicates
-     * TODO:       the resources of parent.*/
+    /* duplciate parent's fd to child.
+     * uni_file이 NULL이 아닐때만 복사합니다.
+     * fils_duplicate에 실패하면 fork가 실패합니다. */
+    lock_acquire(&filesys_lock);
+    for (int fd = 2; fd < FDTABLE_SIZE; fd++)
+    {
+        if (parent->fd_table[fd] != NULL)
+        {
+            struct file *file = parent->fd_table[fd]->ptr;
+            if (file != NULL)
+            {
+                struct file *dup_file = file_duplicate(file);
+                if (dup_file == NULL)
+                {
+                    succ = false;
+                    break;
+                }
+                current->fd_table[fd] = malloc(sizeof(struct uni_file));
+                current->fd_table[fd]->type = FD_FILE;
+                current->fd_table[fd]->ptr = dup_file;
+            }
+        }
+    }
+    lock_release(&filesys_lock);
+    current->next_fd = parent->next_fd;
 
     process_init();
 
-    /* 부모 프로세스로부터 자식 프로세스로의 복제 과정을 성공적으로 마쳤다면, */
+    /* 부모 프로세스 -> 프로세스로 복제 과정을 성공적으로 마쳤다면, */
     if (succ)
     {
-        /* 자식 프로세스의 반환값을 0으로 설정*/
-        if_.R.rax = 0;
+        /* 자식 프로세스는 부모 프로세스에게 성공적으로 복사 과정을 마쳤다는
+         * 것을 알려주면 된다.*/
+        sema_up(&current->fork_sema);
         /* Finally, switch to the newly created process. */
         do_iret(&if_);
     }
 error:
-    if_.R.rax = TID_ERROR;
+    sema_up(&current->fork_sema);
     thread_exit();
 }
 
@@ -191,14 +254,27 @@ error:
  * Returns -1 on fail. */
 int process_exec(void *f_name)
 {
-    char *file_name = f_name;
-    bool success;
-    /* passing */
-    char *argv[MAX_ARGS];
+    char *fn_copy = f_name;
+    char *argv[MAX_ARGS], *token, *save_ptr;
     int argc = 0;
-    char *token, *save_ptr;
+    bool success;
+    if (is_user_vaddr(f_name))
+    {
+        /* copy userland address to kernel area */
+        fn_copy = palloc_get_page(PAL_ZERO);
+        if (fn_copy == NULL)
+        {
+            return -1;
+        }
+        strlcpy(fn_copy, f_name, PGSIZE);
+    }
+    else
+    {
+        /* use straightforward if f_name is already kernel addr */
+        fn_copy = f_name;
+    }
 
-    for (token = strtok_r(file_name, " ", &save_ptr); token != NULL;
+    for (token = strtok_r(fn_copy, " ", &save_ptr); token != NULL;
          token = strtok_r(NULL, " ", &save_ptr))
     {
         argv[argc++] = token;
@@ -220,58 +296,145 @@ int process_exec(void *f_name)
     process_cleanup();
 
     /* And then load the binary */
-    success = load(argv[0], &_if, argv, argc);
+    success = load(fn_copy, &_if, argv, argc);
 
     /* If load failed, quit. */
-    palloc_free_page(file_name);
-    if (!success) return -1;
+    palloc_free_page(fn_copy);
+    if (!success)
+    {
+        return -1;
+    }
 
     /* Start switched process. */
     do_iret(&_if);
     NOT_REACHED();
 }
 
-/* Waits for thread TID to die and returns its exit status.  If
- * it was terminated by the kernel (i.e. killed due to an
- * exception), returns -1.  If TID is invalid or if it was not a
- * child of the calling process, or if process_wait() has already
- * been successfully called for the given TID, returns -1
- * immediately, without waiting.
- *
- * This function will be implemented in problem 2-2.  For now, it
- * does nothing. */
-int process_wait(tid_t child_tid)
+/* 해당 file descriptor 번호로 fdt에서 파일을 찾아 반환. */
+struct uni_file *process_get_file(int fd)
 {
     struct thread *curr = thread_current();
-    struct list_elem *e;
-    struct thread *child_thread;
 
-    for (e = list_begin(&curr->child_list); e != list_end(&curr->child_list);
-         e = list_next(e))
+    if (curr->fd_table[fd] == NULL)
     {
-        child_thread = list_entry(e, struct thread, elem);
-        if (child_thread->tid == child_tid && child_thread->exit_status != -1)
-        {
-            sema_down(&curr->thread_sema);
-            return child_thread->exit_status;
-        }
-        else
-        {
-            return -1;
-        }
+        return NULL;
+    }
+    return curr->fd_table[fd];
+}
+
+/* 현재 실행 중인 프로세스의 열린 파일 리스트에 파일 추가
+ * 파일 디스크립터 handle 번호 반환. */
+int process_add_file(struct file *file)
+{
+    if (file == NULL)
+    {
+        return -1;
     }
 
-    sema_down(&curr->thread_sema);
-    return curr->exit_status;
+    struct thread *curr = thread_current();
+
+    curr->fd_table[curr->next_fd] = malloc(sizeof(struct uni_file));
+
+    curr->fd_table[curr->next_fd]->type = FD_FILE;
+    curr->fd_table[curr->next_fd]->ptr = file;
+
+    return curr->next_fd++;
+}
+
+/* fork로부터 반환된 child의 tid로 현재 부모 프로세스의 자식 리스트에서
+ * 해당 자식 프로세스가 등록되어있는지 확인한다.
+ * 자식이 있으면 해당 자식 스레드 구조체를 반환하고, 없으면 NULL을 반환한다. */
+struct thread *process_get_child(tid_t tid)
+{
+    struct thread *cur = thread_current();
+    struct list *child_list = &cur->child_list;
+
+    for (struct list_elem *e = list_begin(child_list);
+         e != list_end(child_list); e = list_next(e))
+    {
+        struct thread *t = list_entry(e, struct thread, child_elem);
+        if (t->tid == tid) return t;
+    }
+    return NULL;
+}
+
+/* 스레드 TID가 종료될 때까지 대기하고, 종료 상태(exit status)를 반환합니다.
+ * 만약 커널에 의해 종료되었을 경우(즉 예외로 인해 강제 종료된 경우), -1을
+ * 반환합니다. TID가 유효하지 않거나 호출 프로세스의 자식이 아니거나, 이미 해당
+ * TID에 대해 process_wait()가 성공적으로 호출된 적이 있다면, 대기 없이 즉시
+ * -1을 반환합니다. */
+int process_wait(tid_t child_tid)
+{
+    struct thread *child = process_get_child(child_tid);
+
+    /* 현재 부모의 직계 자식이 아닌 경우 즉시 -1 반환 */
+    if (child == NULL)
+    {
+        return -1;
+    }
+
+    /* 이미 해당 TID에 대해 wait를 호출한 적이 있다면 즉시 -1 반환*/
+    if (child->wait_called)
+    {
+        return -1;
+    }
+    child->wait_called = true;
+
+    /* 자식 프로세스의 실행이 끝날 때 까지 대기 */
+    sema_down(&child->wait_sema);
+
+    /* 자식 프로세스가 wait sema에 대해 sema up을 하게 된다는 것은 자식의
+     * 실행이 모두 끝났다는 것을 의미한다. 그러므로 부모의 자식 리스트에서 현재
+     * 자식을 제거한다. */
+    list_remove(&child->child_elem);
+
+    /* 부모는 자식의 종료 과정을 확인하고 다시 exit_sema를 올려서 자식의 종료
+     * 과정을 정상적으로 처리할 수 있도록 한다.*/
+    sema_up(&child->exit_sema);
+
+    /* 자식의 종료 코드를 반환한다. */
+    return child->exit_status;
 }
 
 /* Exit the process. This function is called by thread_exit (). */
 void process_exit(void)
 {
-    struct thread *curr = thread_current();  // 나 응애 자식
-    sema_up(&curr->parent->thread_sema);
+    struct thread *curr = thread_current();
 
-    printf("%s: exit(%d)\n", curr->name, curr->exit_status);
+    /* 자식 프로세스가 종료되었음을 부모에게 알림.
+     * 부모는 process_wait()에서 wait_sema를 기다리고 있다. */
+    sema_up(&curr->wait_sema);
+
+    /* close execution file here */
+    if (curr->running_file != NULL)
+    {
+        lock_acquire(&filesys_lock);
+        file_close(curr->running_file);
+        curr->running_file = NULL;
+        lock_release(&filesys_lock);
+    }
+
+    /* malloc으로 할당했던 모든 파일디스크립터 정리 */
+    for (int i = 0; i < FDTABLE_SIZE; i++)
+    {
+        if (curr->fd_table[i] != NULL)
+        {
+            struct uni_file *uni_file = curr->fd_table[i];
+
+            lock_acquire(&filesys_lock);
+            file_close((struct file *) uni_file->ptr);
+            lock_release(&filesys_lock);
+
+            free(uni_file);
+            curr->fd_table[i] = NULL;
+        }
+    }
+
+    /* 이후 부모가 자식의 종료 상태를 알 수 있도록 exit_sema를 활용해
+     * 자식은 다시 잠든다. */
+    sema_down(&curr->exit_sema);
+
+    /* 부모가 exit_sema로 깨웠을 때 마무리 작업을 통해 프로세스를 정리한다. */
     process_cleanup();
 }
 
@@ -390,23 +553,24 @@ static bool load(const char *file_name, struct intr_frame *if_, char **argv,
     int i;
     char *unused_ptr;
 
-    // file_name = strtok_r(file_name, " ", &unused_ptr);
-    // memset(unused_ptr + 1, 0, (strlen(unused_ptr + 1)));
-    // file_name = strlcpy(file_name, file_name, strlen(file_name));
-
     /* Allocate and activate page directory. */
     t->pml4 = pml4_create();
     if (t->pml4 == NULL) goto done;
     process_activate(thread_current());
 
     /* Open executable file. */
+
+    lock_acquire(&filesys_lock);
     file = filesys_open(file_name);
+    lock_release(&filesys_lock);
+
     if (file == NULL)
     {
         printf("load: %s: open failed\n", file_name);
         goto done;
     }
 
+    lock_acquire(&filesys_lock);
     /* Read and verify executable header. */
     if (file_read(file, &ehdr, sizeof ehdr) != sizeof ehdr ||
         memcmp(ehdr.e_ident, "\177ELF\2\1\1", 7) || ehdr.e_type != 2 ||
@@ -417,8 +581,10 @@ static bool load(const char *file_name, struct intr_frame *if_, char **argv,
         printf("load: %s: error loading executable\n", file_name);
         goto done;
     }
+    lock_release(&filesys_lock);
 
     /* Read program headers. */
+    lock_acquire(&filesys_lock);
     file_ofs = ehdr.e_phoff;
     for (i = 0; i < ehdr.e_phnum; i++)
     {
@@ -476,6 +642,12 @@ static bool load(const char *file_name, struct intr_frame *if_, char **argv,
                 break;
         }
     }
+    lock_release(&filesys_lock);
+
+    /* deny write on executing file */
+    lock_acquire(&filesys_lock);
+    file_deny_write(file);
+    lock_release(&filesys_lock);
 
     /* Set up stack. */
     if (!setup_stack(if_, argv, argc)) goto done;
@@ -487,7 +659,8 @@ static bool load(const char *file_name, struct intr_frame *if_, char **argv,
 
 done:
     /* We arrive here whether the load is successful or not. */
-    file_close(file);
+    /* save current execution file info on thread struct. */
+    t->running_file = file;
     return success;
 }
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -3,25 +3,24 @@
 #include <stdio.h>
 #include <syscall-nr.h>
 
+#include "include/devices/input.h"
 #include "include/filesys/file.h"
 #include "include/filesys/filesys.h"
+#include "include/lib/string.h"
+#include "include/lib/user/syscall.h"
+#include "include/threads/init.h"
 #include "include/userprog/process.h"
 #include "intrinsic.h"
 #include "lib/kernel/console.h"
 #include "threads/flags.h"
 #include "threads/interrupt.h"
 #include "threads/loader.h"
+#include "threads/malloc.h"
 #include "threads/thread.h"
 #include "userprog/gdt.h"
 
 void syscall_entry(void);
 void syscall_handler(struct intr_frame *);
-static bool check_bad_addr();
-static int write_handler(int fd, const void *buffer, unsigned size);
-static int close_handler(int fd);
-struct file *process_get_file(int fd);
-
-static int write_handler(int fd, const void *buffer, unsigned size);
 
 /* System call.
  *
@@ -36,7 +35,31 @@ static int write_handler(int fd, const void *buffer, unsigned size);
 #define MSR_LSTAR 0xc0000082        /* Long mode SYSCALL target */
 #define MSR_SYSCALL_MASK 0xc0000084 /* Mask for the eflags */
 
-// 시스템 초기화 시 시스템 콜 벡터 설정 등의 초기화 작업 수행
+struct lock filesys_lock;
+
+/* check address for validation
+ * - 커널 영역 접근 차단
+ * - 미매핑 페이지 차단 */
+void check_address(void *vaddr)
+{
+    struct thread *curr = thread_current();
+    if (vaddr == NULL || !is_user_vaddr(vaddr) ||
+        pml4_get_page(curr->pml4, vaddr) == NULL)
+    {
+        exit(-1);
+    }
+}
+
+/* protect from bad file descriptor number */
+void check_fd(int fd)
+{
+    if (fd < 0 || fd > FDTABLE_SIZE)
+    {
+        exit(-1);
+    }
+}
+
+/* 시스템 초기화 시 시스템 콜 벡터 설정 등의 초기화 작업 수행 */
 void syscall_init(void)
 {
     write_msr(MSR_STAR, ((uint64_t) SEL_UCSEG - 0x10) << 48 |
@@ -48,27 +71,316 @@ void syscall_init(void)
      * mode stack. Therefore, we masked the FLAG_FL. */
     write_msr(MSR_SYSCALL_MASK,
               FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
+
+    /* initialize filesys lock */
+    lock_init(&filesys_lock);
+}
+
+/* system power off */
+void halt(void)
+{
+    power_off();
+}
+
+/* exit with given status number */
+void exit(int status)
+{
+    struct thread *t = thread_current();
+    t->exit_status = status;
+    printf("%s: exit(%d)\n", t->name,
+           t->exit_status); /* Process Termination Message */
+
+    if (lock_held_by_current_thread(&filesys_lock))
+    {
+        lock_release(&filesys_lock);
+    }
+
+    thread_exit();
+}
+
+// pid_t fork(const char *thread_name)
+// {
+//     struct intr_frame *if_ =
+//         pg_round_up(&thread_name) - sizeof(struct intr_frame);
+//     return process_fork(thread_name, if_);
+// }
+
+/* execute program with given file name */
+int exec(const char *file)
+{
+    check_address(file);
+
+    int result = process_exec(file);
+    if (result == -1)
+    {
+        exit(-1);
+    }
+
+    return result;
+}
+
+/* wait process until it's finish (exit) */
+int wait(pid_t pid)
+{
+    return process_wait(pid);
+}
+
+bool create(const char *file, unsigned initial_size)
+{
+    bool file_create_result = false;
+
+    check_address(file);
+
+    lock_acquire(&filesys_lock);
+    file_create_result = filesys_create(file, initial_size);
+    lock_release(&filesys_lock);
+    return file_create_result;
+}
+
+bool remove(const char *file)
+{
+    check_address(file);
+
+    bool file_remove_result = false;
+
+    lock_acquire(&filesys_lock);
+    file_remove_result = filesys_remove(file);
+    lock_release(&filesys_lock);
+
+    return file_remove_result;
+}
+
+int open(const char *file)
+{
+    check_address(file);
+
+    lock_acquire(&filesys_lock);
+    struct file *open_file = filesys_open(file);
+    lock_release(&filesys_lock);
+
+    if (open_file != NULL)
+    {
+        return process_add_file(open_file);
+    }
+    else
+    {
+        return -1;
+    }
+}
+
+int filesize(int fd)
+{
+    check_fd(fd);
+
+    struct uni_file *uni_file = process_get_file(fd);
+    if (uni_file == NULL)
+    {
+        return -1;
+    }
+
+    struct file *file = uni_file->ptr;
+    if (file == NULL)
+    {
+        return -1;
+    }
+
+    return file_length(file);
+}
+
+int read(int fd, void *buffer, unsigned length)
+{
+    check_address(buffer);
+    check_fd(fd);
+
+    int bytes_read;
+
+    if (fd == FD_STDIN)
+    {
+        /* >> (1) STDIN - 키보드에서 length 바이트만큼 읽기 */
+        unsigned i;
+        for (i = 0; i < length; i++)
+        {
+            /* 한 글자씩 채움 */
+            ((char *) buffer)[i] = input_getc();
+        }
+
+        return length;
+    }
+    else if (fd == FD_STDOUT)
+    {
+        /* >> (2) STDOUT - Not allowed to read on Write-Only file */
+        return -1;
+    }
+    else
+    {
+        /* >> (3): read from file */
+        struct uni_file *uni_file = process_get_file(fd);
+        if (uni_file == NULL)
+        {
+            return -1;
+        }
+
+        struct file *file = uni_file->ptr;
+        if (file == NULL)
+        {
+            return -1;
+        }
+
+        lock_acquire(&filesys_lock);
+        bytes_read = file_read(file, buffer, length);
+        lock_release(&filesys_lock);
+
+        return bytes_read;
+    }
+}
+
+int write(int fd, const void *buffer, unsigned size)
+{
+    check_address(buffer);
+    check_fd(fd);
+
+    struct thread *curr = thread_current();
+
+    if (fd == FD_STDIN)
+    {
+        /* >> (1): writing on Read-Only file is not allowed */
+        return -1;
+    }
+    else if (fd == FD_STDOUT)
+    {
+        /* >> (2): write on STDOUT */
+        putbuf((char *) buffer, size);
+        return size;
+    }
+    else
+    {
+        /* >> (3): write on file */
+        struct uni_file *uni_file = process_get_file(fd);
+        if (uni_file == NULL)
+        {
+            return -1;
+        }
+
+        struct file *file = uni_file->ptr;
+        if (file == NULL)
+        {
+            return -1;
+        }
+
+        lock_acquire(&filesys_lock);
+        int bytes_written = file_write(file, buffer, size);
+        lock_release(&filesys_lock);
+        return bytes_written;
+    }
+}
+
+/* fd로 열린 파일에서 읽거나 쓸 다음 바이트를 파일 시작부터 position(바이트
+ * 단위) 위치로 설정합니다. (따라서 position이 0이면 파일의 시작을 의미합니다.)
+ * 파일의 현재 끝을 넘어서는 seek는 오류가 아닙니다. 이후 read는 0바이트를
+ * 반환하여 파일 끝을 나타냅니다. 이후 write는 파일을 확장하며,
+ * 쓰이지 않은 간격을 0으로 채웁니다.
+ * (그러나 Pintos에서는 프로젝트 4가 완료될 때까지 파일 길이가 고정되어
+ * 있으므로, 파일 끝을 넘는 쓰기는 오류를 반환합니다.) 이러한 동작 방식은 파일
+ * 시스템에 구현되어 있으므로 system call 구현에서 별도의 작업이 필요하지
+ * 않습니다. */
+void seek(int fd, unsigned position)
+{
+    check_fd(fd);
+
+    if (fd == FD_STDIN || fd == FD_STDOUT)
+    {
+        return;
+    }
+
+    struct uni_file *uni_file = process_get_file(fd);
+    if (uni_file == NULL)
+    {
+        return;
+    }
+
+    struct file *file = uni_file->ptr;
+    if (file == NULL)
+    {
+        return;
+    }
+
+    file_seek(file, position);
+}
+
+unsigned tell(int fd)
+{
+    check_fd(fd);
+
+    if (fd == FD_STDIN || fd == FD_STDOUT)
+    {
+        return 0;
+    }
+
+    struct uni_file *uni_file = process_get_file(fd);
+    if (uni_file == NULL)
+    {
+        return -1;
+    }
+
+    struct file *file = uni_file->ptr;
+    if (file == NULL)
+    {
+        return;
+    }
+
+    unsigned position = file_tell(file);
+    return position;
+}
+
+void close(int fd)
+{
+    check_fd(fd);
+
+    if (fd == FD_STDIN || fd == FD_STDOUT)
+    {
+        return;
+    }
+
+    struct thread *curr = thread_current();
+    struct uni_file *uni_file = curr->fd_table[fd];
+    if (uni_file == NULL)
+    {
+        return;
+    }
+
+    if (uni_file->type == FD_FILE && uni_file->ptr != NULL)
+    {
+        lock_acquire(&filesys_lock);
+        file_close((struct file *) uni_file->ptr);
+        lock_release(&filesys_lock);
+    }
+
+    free(uni_file);
+    curr->fd_table[fd] = NULL;
 }
 
 /* The main system call interface */
-// 어셈블리 코드(syscall-entry.S)로부터 제어를 넘겨받음
+/*
+ * 어셈블리 코드(syscall-entry.S)로부터 제어를 넘겨받음
+ * 인터럽트 프레임(struct intr_frame *f)을 통해 사용자 프로그램의
+ * 레지스터 상태와 시스템 콜 번호 및 인자들을 읽어옴
+ */
 void syscall_handler(struct intr_frame *f UNUSED)
 {
-    // 유저 스택에서 시스템콜 번호 꺼내기
+    /* 유저 스택에서 시스템콜 번호 꺼내기 */
     int syscall_number = f->R.rax;
 
     switch (syscall_number)
     {
         case SYS_HALT:
         {
-            power_off();
+            halt();
             break;
         }
         case SYS_EXIT:
         {
-            struct thread *curr = thread_current();
-            curr->exit_status = f->R.rdi;
-            thread_exit();
+            exit(f->R.rdi);
+            break;
         }
         case SYS_FORK:
         {
@@ -77,205 +389,58 @@ void syscall_handler(struct intr_frame *f UNUSED)
         }
         case SYS_EXEC:
         {
-            printf("exec syscall called!!!\n");
+            f->R.rax = exec(f->R.rdi);
             break;
         }
         case SYS_WAIT:
         {
-            f->R.rax = process_wait(f->R.rdi);
+            f->R.rax = wait(f->R.rdi);
             break;
         }
         case SYS_CREATE:
         {
-            const char *open_filename = (const char *) f->R.rdi;
-            int32_t filesize = f->R.rsi;
-            struct thread *curr = thread_current();
-
-            if (open_filename == NULL ||
-                check_bad_addr(open_filename, curr) == NULL)
-            {
-                curr->tf.R.rax = -1;
-                thread_exit();
-            }
-            else
-            {
-                f->R.rax = filesys_create(open_filename, filesize);
-                break;
-            }
+            f->R.rax = create(f->R.rdi, f->R.rsi);
+            break;
         }
         case SYS_REMOVE:
         {
-            printf("remove syscall called!!!\n");
+            f->R.rax = remove(f->R.rdi);
             break;
         }
         case SYS_OPEN:
         {
-            struct thread *curr = thread_current();
-            if (is_user_vaddr(f->R.rdi))
-            {
-                const char *open_filename = (const char *) f->R.rdi;
-                if (open_filename == NULL ||
-                    check_bad_addr(open_filename, curr) == NULL)
-                {
-                    curr->tf.R.rax = -1;
-                    thread_exit();
-                }
-                else
-                {
-                    struct file *open_file = filesys_open(open_filename);
-
-                    if (open_file != NULL)
-                    {
-                        f->R.rax = process_add_file(open_file);
-                    }
-                    else
-                    {
-                        f->R.rax = -1;
-                    }
-                    break;
-                }
-            }
+            f->R.rax = open(f->R.rdi);
+            break;
         }
         case SYS_FILESIZE:
         {
-            struct file *current_file = process_get_file(f->R.rdi);
-            f->R.rax = file_length(current_file);
+            f->R.rax = filesize(f->R.rdi);
             break;
         }
         case SYS_READ:
         {
-            struct thread *current_thread = thread_current();
-
-            if (!is_fd_readable(f->R.rdi) ||
-                check_bad_addr(f->R.rsi, current_thread) == NULL)
-            {
-                current_thread->tf.R.rax = -1;
-                thread_exit();
-            }
-
-            struct file *current_file = process_get_file(f->R.rdi);
-            f->R.rax = file_read(current_file, f->R.rsi, f->R.rdx);
+            f->R.rax = read(f->R.rdi, f->R.rsi, f->R.rdx);
             break;
         }
         case SYS_WRITE:
         {
-            // 인터럽트 프레임(struct intr_frame *f)을 통해 사용자 프로그램의
-            // 레지스터 상태와 시스템 콜 번호 및 인자들을 읽어옴 f->R.rax :
-            // 시스템 콜 반환값 (리턴값 저장) f->R.rdi : 첫 번째 인자 (fd)
-            // f->R.rsi : 두 번째 인자 (buffer)
-            // f->R.rdx : 세 번째 인자 (size)
-            f->R.rax = write_handler(f->R.rdi, f->R.rsi, f->R.rdx);
+            f->R.rax = write(f->R.rdi, f->R.rsi, f->R.rdx);
             break;
         }
         case SYS_SEEK:
         {
-            printf("seek syscall called!!!\n");
+            seek(f->R.rdi, f->R.rsi);
             break;
         }
         case SYS_TELL:
         {
-            printf("tell syscall called!!!\n");
+            f->R.rax = tell(f->R.rdi);
             break;
         }
         case SYS_CLOSE:
         {
-            // fd_list에서 fd를 가진 file_fd 찾아서
-            // 리스트에서 제거하고 file_fd 메모리 해제
-            close_handler(f->R.rdi);
+            close(f->R.rdi);
             break;
         }
     }
-}
-
-static bool check_bad_addr(const char *vaddr, struct thread *t)
-{
-    return pml4_get_page(t->pml4, vaddr);
-}
-
-/* 파일 또는 STDOUT으로 쓰기 */
-static int write_handler(int fd, const void *buffer, unsigned size)
-{
-    struct thread *current_thread = thread_current();
-
-    if (!is_fd_writable(fd) || check_bad_addr(buffer, current_thread) == NULL)
-    {
-        current_thread->tf.R.rax = -1;
-        thread_exit();
-    }
-
-    if (!(is_user_vaddr(buffer) && is_user_vaddr(buffer + size)))
-    {
-        return -1;
-    }
-
-    switch (fd)
-    {
-        case 1: /* fd가 1이면 표준 출력 (파일이 아니라 콘솔로 출력) */
-        {
-            putbuf(buffer, size);
-        }
-        default: /* open()으로 연 파일이 할당된 경우 */
-        {
-            struct file *file = process_get_file(fd);
-            if (file == NULL) return -1;
-            return file_write(file, buffer, size);
-        }
-    }
-}
-
-static int close_handler(int fd)
-{
-    struct thread *current_thread = thread_current();
-
-    if (fd < 2 || fd > 127)
-    {
-        return -1;
-    }
-
-    if (current_thread->fdt[fd] == NULL)
-    {
-        return -1;
-    }
-    else
-    {
-        current_thread->fdt[fd] = NULL;
-        free(current_thread->fdt[fd]);
-        return 0;
-    }
-}
-
-// 헌재 실행 중인 프로세스의 열린 파일 리스트에서 특정 파일 디스크립터(fd)에
-// 해당하는 파일 포인터를 찾아 반환
-struct file *process_get_file(int fd)
-{
-    struct thread *current_thread = thread_current();
-
-    if (current_thread->fdt[fd]->fd_type == FD_TYPE_FILE &&
-        current_thread->fdt[fd]->fd_ptr != NULL)
-    {
-        return current_thread->fdt[fd]->fd_ptr;
-    }
-    else
-    {
-        return NULL;
-    }
-}
-
-// 현재 실행 중인 프로세스의 열린 파일 리스트에 파일 추가
-int process_add_file(struct file *file)
-{
-    if (file == NULL)
-    {
-        return -1;
-    }
-
-    struct thread *current_thread = thread_current();
-
-    current_thread->fdt[current_thread->next_fd] =
-        malloc(sizeof(struct uni_file));
-
-    current_thread->fdt[current_thread->next_fd]->fd_type = FD_TYPE_FILE;
-    current_thread->fdt[current_thread->next_fd]->fd_ptr = file;
-
-    return current_thread->next_fd++;
 }


### PR DESCRIPTION
## 📑 개요

Pintos 운영체제에 핵심적인 프로세스 관리 기능과 파일 시스템 관련 시스템 콜을 구현합니다. 이 PR을 통해 사용자는 프로세스를 생성(`fork`), 실행(`exec`), 대기(`wait`), 종료(`exit`)할 수 있게 되며, 파일 시스템을 이용한 기본적인 I/O 작업이 가능해집니다.

주요 구현 내용은 다음과 같습니다.
- 프로세스 계층 구조 관리를 위한 자료구조(`struct thread`) 확장
- `fork`, `wait`, `exit` 시스템 콜의 동기화를 위한 세마포어 기반 로직 구현
- 파일 디스크립터(FD) 관리 시스템 개선 및 관련 헬퍼 함수 추가
- 모든 파일 시스템 접근에 대한 동기화를 위한 전역 락(`filesys_lock`) 도입
- 사용자 공간 주소의 유효성을 검증하는 `check_address` 함수 구현
- 전체 시스템 콜 핸들러 리팩토링 및 기능 구현

## ✨ 주요 변경 사항

### 1. 프로세스 관리 및 동기화 (`fork`, `wait`, `exit`)

- **`struct thread` 확장**:
    - `child_list`, `child_elem`: 부모-자식 관계를 관리하기 위한 리스트 구조를 추가했습니다.
    - `parent_if`: `fork` 시 자식 프로세스에게 부모의 인터럽트 프레임을 전달하기 위한 멤버를 추가했습니다.
    - `wait_sema`, `fork_sema`, `exit_sema`: `wait`, `fork`, `exit` 시스템 콜의 동기화를 위해 3개의 세마포어를 추가했습니다.
        - `fork_sema`: `fork` 시 자식 프로세스의 자원 복제가 완료될 때까지 부모가 대기하는 데 사용됩니다.
        - `wait_sema`: 자식 프로세스가 종료될 때까지 부모가 `wait`에서 대기하는 데 사용됩니다.
        - `exit_sema`: `wait`을 호출한 부모가 자식의 종료 상태를 수집한 후, 자식 프로세스가 최종적으로 종료되도록 허용하는 데 사용됩니다.
    - `exit_status`: 자식 프로세스의 종료 코드를 저장하여 부모에게 전달합니다.
    - `wait_called`: 동일한 자식에 대해 `wait`이 중복 호출되는 것을 방지하기 위한 플래그입니다.
    - `running_file`: 현재 실행 중인 실행 파일을 가리키는 포인터로, 프로세스 종료 시 `file_close`를 위함입니다.

- **`process_fork()` 및 `__do_fork()` 구현**:
    - 부모의 자원(페이지 테이블, 파일 디스크립터)을 자식에게 복제합니다.
    - `duplicate_pte`를 통해 부모의 페이지 테이블을 복사하고, `file_duplicate`를 통해 열린 파일들을 복제합니다.
    - `fork_sema`를 사용하여 부모-자식 간의 생성 과정을 동기화합니다. 자식의 `__do_fork`가 성공적으로 끝나야 부모의 `process_fork`가 반환됩니다.

- **`process_wait()` 구현**:
    - `process_get_child()`를 통해 tid로 자식 프로세스를 찾습니다.
    - `wait_sema`를 통해 자식 프로세스가 종료될 때까지 대기(`sema_down`)합니다.
    - 자식의 종료 후 `exit_status`를 반환하고, 자식 리스트에서 해당 자식을 제거합니다.

- **`process_exit()` 구현**:
    - 열려있는 모든 파일 디스크립터를 닫고, 실행 중인 파일(`running_file`)을 `file_close` 합니다.
    - `wait_sema`를 `sema_up`하여 `wait` 중인 부모를 깨웁니다.
    - `exit_sema`를 `sema_down`하여 부모가 `exit_status`를 완전히 처리할 때까지 대기한 후 최종 정리(`process_cleanup`)를 수행합니다.

### 2. 파일 디스크립터(FD) 관리 리팩토링

- **`struct uni_file` 및 `fd_table` 도입**:
    - 기존의 `file_descriptor_table`을 `uni_file` 구조체를 사용하는 `fd_table`로 대체했습니다.
    - `uni_file`은 파일의 타입(`FD_STDIN`, `FD_STDOUT`, `FD_FILE` 등)과 실제 파일 객체 포인터를 함께 관리하여 FD 처리를 일원화했습니다.
    - FD 테이블의 최대 크기를 `FDTABLE_SIZE` (64)로 조정했습니다.

- **FD 관리 헬퍼 함수 추가 (`userprog/process.c`)**:
    - `process_init_fdt()`: 스레드 생성 시 FD 테이블을 초기화하고 STDIN/STDOUT을 설정합니다.
    - `process_add_file()`: 새로 열린 파일을 FD 테이블에 추가하고 fd 번호를 반환합니다.
    - `process_get_file()`: fd 번호로 FD 테이블에서 `uni_file` 객체를 조회합니다.

### 3. 시스템 콜 프레임워크 및 핸들러 구현

- **전역 파일 시스템 락 (`filesys_lock`)**:
    - `syscall.c`에 `filesys_lock`을 추가하고 `syscall_init`에서 초기화했습니다.
    - `filesys_open`, `filesys_create`, `file_read` 등 모든 파일 시스템 관련 함수 호출을 이 락으로 감싸, 파일 시스템 연산의 원자성을 보장합니다.

- **주소 유효성 검사 (`check_address`)**:
    - 시스템 콜 인자로 전달된 사용자 주소가 유효한지(NULL이 아니고, 유저 영역에 있으며, 매핑된 페이지인지) 검사하는 `check_address` 함수를 구현했습니다. 유효하지 않은 주소 접근 시 프로세스를 즉시 종료(`exit(-1)`)시킵니다.

- **시스템 콜 핸들러 구현 (`syscall.c`)**:
    - `syscall_handler`의 `switch` 문을 통해 각 시스템 콜 번호에 맞는 핸들러 함수를 호출하도록 리팩토링했습니다.
    - `halt`, `exit`, `exec`, `create`, `remove`, `open`, `filesize`, `read`, `write`, `seek`, `tell`, `close` 등 모든 필수 시스템 콜의 로직을 구현했습니다.
    - `read`/`write`는 fd 값에 따라 STDIN/STDOUT 또는 일반 파일을 구분하여 처리합니다.

### 4. 기타 변경 및 개선 사항

- **`process.c` (`load` 함수)**:
    - 실행 파일을 `load`할 때 `file_deny_write()`를 호출하여 실행 중인 파일이 수정되는 것을 방지합니다.
    - `load`가 성공하면 파일 포인터를 `thread->running_file`에 저장하고, 프로세스가 종료될 때 `process_exit`에서 닫도록 변경했습니다.

- **`exception.c` (`page_fault`)**:
    - 페이지 폴트 발생 시 `kill(f)` 대신 `exit(-1)`을 호출하여 프로세스를 표준적인 방법으로 종료하도록 수정했습니다.

- **`thread.c`**:
    - `thread_create()` 시 새로운 스레드를 부모의 `child_list`에 등록합니다.
    - `thread_yield_r()` 함수를 추가하여, 준비 큐의 맨 앞 스레드와 현재 스레드의 우선순위를 비교 후 필요할 때만 `yield` 하도록 최적화했습니다.

- **IDE 설정 (`.vscode/settings.json`)**:
    - 새로운 헤더 파일들을 C언어 파일로 인식하도록 VSCode 설정을 업데이트하여 개발 편의성을 높였습니다.

